### PR TITLE
Fixed Links

### DIFF
--- a/vem/demand/cet.md
+++ b/vem/demand/cet.md
@@ -10,7 +10,7 @@ In order to understand how carbon is spread across a supply chain and to effecti
 
 At a high level, one participant's scope 1 emissions, become another participants scope 2 for direct energy consumption. Scope 3 emissions flow upstream and need to be calculated, which is complex process that involves estimations at best with a bit of guess work thrown in. If full track and trace for scope 1 & 2 emissions can be capture by enough participants in a supply chain, it should be able to be overladed with trade flows between the supply chain to more be a more straight forward and accurate calculation.
 
-One additional aspect for CETs, is their offsetting with [CCPs](../offsets/ccp.md) and allowing that offset to cascade through the emissions reporting within a supply chain. Where any implementation of offsets should ensure that an offset cannot be spent or applied twice for scope 1 emissions, it DOES want to ensure that any offset that decreases a downstream participant's emissions also decreases proportionately for the upstream consumers calculating their scope 3 emissions.
+One additional aspect for CETs, is their offsetting with [CCPs](../supply/ccp.md) and allowing that offset to cascade through the emissions reporting within a supply chain. Where any implementation of offsets should ensure that an offset cannot be spent or applied twice for scope 1 emissions, it DOES want to ensure that any offset that decreases a downstream participant's emissions also decreases proportionately for the upstream consumers calculating their scope 3 emissions.
 
 Using both a CET to account for emissions and a COT to account for an offset/reduction allows for this behavior in any implementation.
 

--- a/vem/readme.md
+++ b/vem/readme.md
@@ -68,6 +68,6 @@ One a participant owns a credit they wish to use as an offset against their emis
 
 The VEM will generate its token, interwork and analytic standards using the IWA frameworks and can be found in the framework libraries.
 
-Both the [demand](demand) and [supply](supply) folders contain working documents for discussion and providing background for the tokenization of a [Carbon Emission Token](emissions/cet.md) and a [Core Carbon Principle Credit](credits/ccp.md). These tokens will represent the minimally viable shared data required for the multi-party scenarios for buyers, sellers and investors in these digital assets.  These tokens will be related to "contracts" like emissions reporting and goal pledges, carbon removal projects and other entities defined across the lifecycle phases.
+Both the [demand](demand) and [supply](supply) folders contain working documents for discussion and providing background for the tokenization of a [Carbon Emission Token](demand/cet.md) and a [Core Carbon Principle Credit](supply/ccp.md). These tokens will represent the minimally viable shared data required for the multi-party scenarios for buyers, sellers and investors in these digital assets.  These tokens will be related to "contracts" like emissions reporting and goal pledges, carbon removal projects and other entities defined across the lifecycle phases.
 
 ![VEM Frameworks](images/VEM-Tools.png)

--- a/vem/supply/ccp.md
+++ b/vem/supply/ccp.md
@@ -49,7 +49,7 @@ Core Carbon Attributes contain:
 
 ## Using CCP
 
-CCPs can be held for their value or spent to offset reported emissions in either a voluntary or a regulated environment. When an owner offsets a CCP, it is applied towards an ESG Goal or other target and is retired or burned and cannot be offset again. [See ESG Scorecard](../emissions/ESG-Scorecard.md)
+CCPs can be held for their value or spent to offset reported emissions in either a voluntary or a regulated environment. When an owner offsets a CCP, it is applied towards an ESG Goal or other target and is retired or burned and cannot be offset again. [See ESG Scorecard](../demand/ESG-Scorecard.md)
 
 ## Issues with CCP
 

--- a/vem/supply/cru.md
+++ b/vem/supply/cru.md
@@ -43,13 +43,13 @@ Core Carbon Attributes contain:
 - PA-Compliance:
   - Corresponding Adjustment
 
-**The complete draft of the TTF specification, including its token base and behaviors, for the [Carbon Removal Unit token](https://github.com/InterWorkAlliance/TokenTaxonomyFramework/tree/main/artifacts/token-templates/specifications/Carbon-Removal-Unit/latest).**
+**The complete draft of the TTF specification, including its token base and behaviors, for the [Carbon Removal Unit token](https://github.com/InterWorkAlliance/TTF/tree/master/artifacts/token-templates/specifications/Carbon-Removal-Unit/latest).**
 
 ![CRU-TTF](../images/cru-ttf.png)
 
 ## Using CRU
 
-CRUs can be held for their value or spent to offset reported emissions in either a voluntary or regulated environment. When an owner offsets a CRU, it is applied towards an ESG Goal or other target and is retired or burned and cannot be offset again. [See ESG Scorecard](../emissions/ESG-Scorecard.md)
+CRUs can be held for their value or spent to offset reported emissions in either a voluntary or regulated environment. When an owner offsets a CRU, it is applied towards an ESG Goal or other target and is retired or burned and cannot be offset again. [See ESG Scorecard](../demand/ESG-Scorecard.md)
 
 ## Issues with CRU
 

--- a/vem/trading/readme.md
+++ b/vem/trading/readme.md
@@ -33,6 +33,6 @@ However, through the derivatives instruments (spot/forwards/futures), there woul
 
 As a voluntary market can offer both standardized carbon credits like a commodity, a.k.a. a standard reference contract that is fungible with other credits in the same class or can be non-fungible custom contracts that can differ in value and also be bundled together based on their Core Carbon Attributes, an implementation should have searchable parameters.
 
-Using the specifications for [Ecological Projects](../credits/ecological-project.md), [Core Carbon Principle Credits](../credits/ccp.md) and [Verification Contracts](../credits/verification.md), buyers should be able build queries to find products based on their buyer preferences.
+Using the specifications for [Ecological Projects](../supply/ep.md), [Core Carbon Principle Credits](../supply/ccp.md) and [Verification Contracts](../supply/verification.md), buyers should be able build queries to find products based on their buyer preferences.
 
 ![ESG Buyer Search](../images/demand-search.png)


### PR DESCRIPTION
Fixed links to point to their intended locations. Some of the links to the token specifications (CRU and EP) link to the private GitHub, so may not be visible to outside viewers.